### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
За допомогою EditorConfig можна автоматично позбавитися непотрібних пробілів в кінцях рядків. За іншими правилами додатково впевнитися, що cимвол нового рядка буде саме LF, а кодування UTF-8.

Детальніше:
- <https://editorconfig.org>
- [Newline symbol in Markdown](https://arcticicestudio.github.io/styleguide-markdown/rules/whitespace.html#newline)

Для EditorConfig є плагіни майже для всіх можливих редакторів, також підтримка GitHub, якщо редагування відбувається через вебверсію.